### PR TITLE
RE-1786 Add Python version check to component tool

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,9 +1,15 @@
 from setuptools import setup, find_packages
+import sys
+
+if sys.version_info < (3, 2) and "install" in str(sys.argv):
+    sys.exit('rpc-component requires Python >= 3.2 '
+             'but the running Python is %s.%s.%s' % sys.version_info[:3])
 
 setup(
     name='rpc_component',
     version='0.0.0',
     description='Tools for managing RPC components.',
+    python_requires='>=3.2',
     install_requires=['GitPython', 'PyYAML', 'schema'],
     packages=find_packages(),
     entry_points={


### PR DESCRIPTION
The component tool will output a syntax error that is difficult to
understand when the tool is run under Python 2.x.  This change involves
modifying the rpc_component scripts to check the Python version and
instruct the user to use Python 3.2+ when the wrong version is being
used.

If we would like to have a python version check also in cli.py, in case
someone is trying to run the cli.py / component.py scripts prior to install,
we would likely need to add "from __future__ import print_function" at
the top of the file and the python version check below that. This will
bypass the print syntax error created by Python 2.x, thus allowing the
version warning to be printed from cli.py

JIRA: RE-1786