### PR TITLE
Add schema for new artifact upload configuration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+*.egg-info
+*.pyc

--- a/README.md
+++ b/README.md
@@ -56,3 +56,9 @@ component --releases-dir . compare --from <sha1> --to <sha2> --verify release
 cd rpc-metadata
 component --releases-dir . release --component-name rpc-product-1 get --version r1.0.0 --pred
 ```
+
+#### Verify and get component metadata
+
+```
+component metadata get
+```

--- a/rpc_component/component.py
+++ b/rpc_component/component.py
@@ -241,9 +241,16 @@ class ComponentError(Exception):
 
 
 def load_data(filepath):
-    with open(filepath) as f:
-        data = yaml.safe_load(f)
-
+    try:
+        with open(filepath) as f:
+            data = yaml.safe_load(f)
+    except yaml.parser.ParserError as e:
+        raise ComponentError(
+            "Invalid YAML:"
+            "\n{e}\n".format(
+                e=e
+            )
+        )
     return data
 
 

--- a/rpc_component/schemata.py
+++ b/rpc_component/schemata.py
@@ -1,3 +1,4 @@
+from collections import ChainMap
 from functools import partial
 import re
 
@@ -134,9 +135,9 @@ component_schema = Schema(
     }
 )
 
-component_metadata_schema = Schema(
+dependencies_schema = Schema(
     {
-        "dependencies": And(
+        Optional("dependencies"): And(
             [
                 {
                     "name": And(str, len),
@@ -144,8 +145,46 @@ component_metadata_schema = Schema(
                 },
             ],
             is_value_unique("name"),
-        ),
+        )
     }
+)
+
+artifacts_file_schema = Schema(
+    {
+        "type": "file",
+        "source": And(str, len),
+        Optional("dest"): And(str, len),
+        Optional("expire_after"): And(int, lambda n: n > 0)
+    }
+)
+
+artifacts_log_schema = Schema(
+    {
+        "type": "log",
+        "source": And(str, len)
+    }
+)
+
+artifacts_schema = Schema(
+    {
+        Optional("artifacts"):
+            [
+                Or(artifacts_file_schema, artifacts_log_schema)
+            ]
+    }
+)
+
+component_metadata_schema = Schema(
+    dict(
+        ChainMap(
+            *(s._schema for s in
+                (
+                    dependencies_schema,
+                    artifacts_schema,
+                )
+              )
+        )
+    )
 )
 
 component_requirements_schema = Schema(

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ if sys.version_info < (3, 2) and "install" in str(sys.argv):
 
 setup(
     name='rpc_component',
-    version='0.0.0',
+    version='0.0.1',
     description='Tools for managing RPC components.',
     python_requires='>=3.2',
     install_requires=['GitPython', 'PyYAML', 'schema'],

--- a/tests/test_schemata.py
+++ b/tests/test_schemata.py
@@ -1,3 +1,4 @@
+import schema
 import unittest
 
 import rpc_component.schemata as schemata
@@ -149,8 +150,130 @@ class TestSchemaValidation(unittest.TestCase):
         )
 
     def test_component_metadata_schema(self):
-        minimal = {"dependencies": []}
-        with_deps = {
+        empty_deps = {
+            "dependencies": []
+        }
+        with_deps_version = {
+            "dependencies": [
+                {
+                    "name": "dep0",
+                    "constraints": ["version<2.0.0"],
+                },
+            ]
+        }
+        with_deps_branch = {
+            "dependencies": [
+                {
+                    "name": "dep1",
+                    "constraints": ["branch==some-branch"],
+                },
+            ]
+        }
+        with_deps_empty = {
+            "dependencies": [
+                {
+                    "name": "dep2",
+                    "constraints": [],
+                },
+            ]
+        }
+        with_deps_multiple = {
+            "dependencies": [
+                {
+                    "name": "dep0",
+                    "constraints": ["version<2.0.0"],
+                },
+                {
+                    "name": "dep1",
+                    "constraints": ["branch==some-branch"],
+                },
+            ]
+        }
+        empty_artifacts = {"artifacts": []}
+        with_artifacts_file = {
+            "artifacts": [
+                {
+                    "type": "file",
+                    "source": "/foo",
+                },
+            ]
+        }
+        with_artifacts_file_expire_integer = {
+            "artifacts": [
+                {
+                    "type": "file",
+                    "source": "/foo",
+                    "dest": "bar",
+                    "expire_after": 300,
+                },
+            ]
+        }
+        with_artifacts_file_expire_string = {
+            "artifacts": [
+                {
+                    "type": "file",
+                    "source": "/foo",
+                    "dest": "bar",
+                    "expire_after": "300",
+                },
+            ]
+        }
+        with_artifacts_file_expire_negative = {
+            "artifacts": [
+                {
+                    "type": "file",
+                    "source": "/foo",
+                    "dest": "bar",
+                    "expire_after": -1,
+                },
+            ]
+        }
+        with_artifacts_file_incomplete = {
+            "artifacts": [
+                {
+                    "type": "file",
+                    "dest": "bar",
+                },
+            ]
+        }
+        with_artifacts_file_unknown = {
+            "artifacts": [
+                {
+                    "type": "file",
+                    "source": "foo",
+                    "unknown": "baz",
+                },
+            ]
+        }
+        with_artifacts_log = {
+            "artifacts": [
+                {
+                    "type": "log",
+                    "source": "/foo",
+                },
+            ]
+        }
+        with_artifacts_log_unknown = {
+            "artifacts": [
+                {
+                    "type": "log",
+                    "dest": "bar",
+                },
+            ]
+        }
+        with_artifacts_file_and_log = {
+            "artifacts": [
+                {
+                    "type": "file",
+                    "source": "/foo",
+                },
+                {
+                    "type": "log",
+                    "source": "/foo",
+                },
+            ]
+        }
+        with_deps_and_artifacts = {
             "dependencies": [
                 {
                     "name": "dep0",
@@ -164,14 +287,87 @@ class TestSchemaValidation(unittest.TestCase):
                     "name": "dep2",
                     "constraints": [],
                 },
+            ],
+            "artifacts": [
+                {
+                    "type": "file",
+                    "source": "/foo",
+                },
+                {
+                    "type": "log",
+                    "source": "/foo"
+                },
             ]
         }
 
         self.assertTrue(
-            schemata.component_metadata_schema.validate(minimal)
+            schemata.component_metadata_schema.validate(
+                empty_deps)
         )
         self.assertTrue(
-            schemata.component_metadata_schema.validate(with_deps)
+            schemata.component_metadata_schema.validate(
+                with_deps_version)
+        )
+        self.assertTrue(
+            schemata.component_metadata_schema.validate(
+                with_deps_branch)
+        )
+        self.assertTrue(
+            schemata.component_metadata_schema.validate(
+                with_deps_empty)
+        )
+        self.assertTrue(
+            schemata.component_metadata_schema.validate(
+                with_deps_multiple)
+        )
+        self.assertTrue(
+            schemata.component_metadata_schema.validate(
+                empty_artifacts)
+        )
+        self.assertTrue(
+            schemata.component_metadata_schema.validate(
+                with_artifacts_file)
+        )
+        self.assertTrue(
+            schemata.component_metadata_schema.validate(
+                with_artifacts_file_expire_integer)
+        )
+        self.assertRaises(
+            schema.SchemaError,
+            schemata.component_metadata_schema.validate,
+            with_artifacts_file_expire_string
+        )
+        self.assertRaises(
+            schema.SchemaError,
+            schemata.component_metadata_schema.validate,
+            with_artifacts_file_expire_negative
+        )
+        self.assertRaises(
+            schema.SchemaError,
+            schemata.component_metadata_schema.validate,
+            with_artifacts_file_incomplete
+        )
+        self.assertRaises(
+            schema.SchemaError,
+            schemata.component_metadata_schema.validate,
+            with_artifacts_file_unknown
+        )
+        self.assertTrue(
+            schemata.component_metadata_schema.validate(
+                with_artifacts_log)
+        )
+        self.assertRaises(
+            schema.SchemaError,
+            schemata.component_metadata_schema.validate,
+            with_artifacts_log_unknown
+        )
+        self.assertTrue(
+            schemata.component_metadata_schema.validate(
+                with_artifacts_file_and_log)
+        )
+        self.assertTrue(
+            schemata.component_metadata_schema.validate(
+                with_deps_and_artifacts)
         )
 
     def test_component_schema(self):


### PR DESCRIPTION
In order to facilitate in-repo configuration of artifacts
to be uploaded from jobs, we add the schema validation and
appropriate tests for the new 'artifacts' key and the two
initial types: 'log' and 'file'.

Issue: [RE-1325](https://rpc-openstack.atlassian.net/browse/RE-1325)