### PR TITLE
Fix updating requirements

### DIFF
--- a/rpc_component/cli.py
+++ b/rpc_component/cli.py
@@ -201,7 +201,7 @@ def dependency(components_dir, **kwargs):
     metadata_filename = "component_metadata.yml"
     filepath = os.path.join(dependency_dir, metadata_filename)
     new_metadata = {"artifacts": [], "dependencies": []}
-    metadata = get_metadata(components_dir)
+    metadata = get_metadata(dependency_dir)
 
     subparser = kwargs.pop("dependency_subparser")
     if subparser == "set-dependency":


### PR DESCRIPTION
A recent change, 1a3f0ddac31ff118f4aa2b1d3dd3081d4c353a10, has broken
the command `component dependency update-requirements`. The incorrect
directory is used resulting in the necessary metadata file not being
found. This change updates the code to ensure that the component's
directory is correctly targeted.

JIRA: RE-1964