### PR TITLE
Add comparison verification for artefact stores

### DIFF
--- a/rpc_component/cli.py
+++ b/rpc_component/cli.py
@@ -226,6 +226,23 @@ def compare(releases_dir, components_dir, **kwargs):
             name, _ = comparison.popitem()
             component = [c for c in to if c.name == name][0]
             output = component
+    elif kwargs["verify"] == "artifact-store":
+        try:
+            s_lib.comparison_added_artifact_stores_schema.validate(comparison)
+        except SchemaError as e:
+            raise c_lib.ComponentError(
+                "The changes from `{f}` to `{t}` do not represent the "
+                "addition of one or more new artifact stores.\nValidation "
+                "error:\n{e}\nChanges found:\n{c}".format(
+                    f=kwargs["from"],
+                    t=kwargs["to"],
+                    e=e,
+                    c=comparison_yaml,
+                )
+            )
+        else:
+            _, data = comparison.popitem()
+            output = data["added"]
     else:
         output = comparison
 
@@ -569,7 +586,7 @@ def parse_args(args):
     )
     com_parser.add_argument(
         "--verify",
-        choices=["release", "registration"],
+        choices=["release", "registration", "artifact-store"],
     )
 
     metadata_parser = subparsers.add_parser("metadata")

--- a/rpc_component/schemata.py
+++ b/rpc_component/schemata.py
@@ -239,6 +239,30 @@ comparison_added_component_schema = Schema(
     )
 )
 
+comparison_added_artifact_stores_schema = Schema(
+    And(
+        {
+            And(str, len): {
+                "added": {
+                    "artifact_stores": And(
+                        [
+                            {
+                                "description": Or(str, None),
+                                "name": And(str, len),
+                                "public_url": And(str, len),
+                                "type": And(str, len),
+                            },
+                        ],
+                        is_value_unique("name"),
+                    ),
+                },
+                "deleted": {},
+            }
+        },
+        lambda s: len(s) == 1,
+    )
+)
+
 
 def _version_key(version_id, regex=None):
     prerelease_map = {


### PR DESCRIPTION
This change adds the ability to verify that the difference between to
commits in the rcbops/releases represents the addition of a new artefact
store to a component.

An example use of the new command is:

```
component \
  --releases-dir . \
  compare \
    --from HEAD^ \
    --to HEAD \
    --verify artifact-store
```

JIRA: RE-2100