### PR TITLE
Add JJB path to metadata tracked in component repo

### DIFF
--- a/rpc_component/cli.py
+++ b/rpc_component/cli.py
@@ -321,7 +321,7 @@ def get_metadata(metadata_dir):
     try:
         metadata = c_lib.load_data(filepath)
     except FileNotFoundError:
-        metadata = {"artifacts": [], "dependencies": []}
+        metadata = {"artifacts": [], "dependencies": [], "jenkins": {}}
     return s_lib.component_metadata_schema.validate(metadata)
 
 

--- a/rpc_component/schemata.py
+++ b/rpc_component/schemata.py
@@ -196,6 +196,14 @@ artifacts_schema = Schema(
     }
 )
 
+jenkins_schema = Schema(
+    {
+        Optional("jenkins"): {
+            Optional("jjb_paths"): [And(str, len)],
+        }
+    }
+)
+
 component_metadata_schema = Schema(
     dict(
         ChainMap(
@@ -203,6 +211,7 @@ component_metadata_schema = Schema(
                 (
                     dependencies_schema,
                     artifacts_schema,
+                    jenkins_schema,
                 )
               )
         )

--- a/tests/test_schemata.py
+++ b/tests/test_schemata.py
@@ -289,7 +289,7 @@ class TestSchemaValidation(unittest.TestCase):
                 },
             ]
         }
-        with_deps_and_artifacts = {
+        with_all = {
             "dependencies": [
                 {
                     "name": "dep0",
@@ -313,7 +313,13 @@ class TestSchemaValidation(unittest.TestCase):
                     "type": "log",
                     "source": "/foo"
                 },
-            ]
+            ],
+            "jenkins": {
+                "jjb_paths": [
+                    "foo",
+                    "bar",
+                ],
+            },
         }
 
         self.assertTrue(
@@ -383,7 +389,7 @@ class TestSchemaValidation(unittest.TestCase):
         )
         self.assertTrue(
             schemata.component_metadata_schema.validate(
-                with_deps_and_artifacts)
+                with_all)
         )
 
     def test_component_schema(self):


### PR DESCRIPTION
To enable JJB jobs to be defined in components, this change updates the
component_metadata.yml schema to support specifying paths that can be
used when rebuilding the Jenkins jobs using `jenkins-jobs`. For example,
if used in rpc-gating the following would be added:
```
jenkins:
  jjb_paths:
  - rpc_jobs
```

JIRA: RE-2069